### PR TITLE
Cloudflare CDN fallback for model detection + LL-HLS audio in recordings

### DIFF
--- a/app/ffmpeg_runner.py
+++ b/app/ffmpeg_runner.py
@@ -12,6 +12,20 @@ from .core.http_client import (
     is_socks_proxy,
 )
 
+# Chaturbate LL-HLS master playlists multiplex all quality levels into one stream.
+# Each entry maps a max_height ceiling to the ffmpeg video stream index.
+_LLHLS_QUALITY_LADDER = [(360, 0), (480, 1), (540, 2), (720, 3), (1080, 4)]
+
+
+def _llhls_video_stream_index(max_height: Optional[int]) -> int:
+    """Return the ffmpeg 0:v:N index for the desired quality on an LL-HLS master."""
+    if not max_height or max_height <= 0:
+        return _LLHLS_QUALITY_LADDER[-1][1]
+    for height, idx in _LLHLS_QUALITY_LADDER:
+        if max_height <= height:
+            return idx
+    return _LLHLS_QUALITY_LADDER[-1][1]
+
 
 class FFmpegSession:
     def __init__(self, session_id: str, input_url: str, sessions_dir: str, records_dir_for_person: str, person: str, display_name: Optional[str] = None):
@@ -137,7 +151,7 @@ class FFmpegManager:
                    sessions_root=self.sessions_root,
                    records_root=self.records_root)
 
-    def start_session(self, input_url: str, person: str, display_name: Optional[str] = None) -> FFmpegSession:
+    def start_session(self, input_url: str, person: str, display_name: Optional[str] = None, max_height: Optional[int] = None) -> FFmpegSession:
         logger.ffmpeg_start("new", person, input_url)
         
         with self._lock:
@@ -191,9 +205,20 @@ class FFmpegManager:
                     "mais FFmpeg ne supporte ici que les proxys HTTP(S)"
                 )
 
+            # For Chaturbate LL-HLS master playlists, the master URL contains
+            # both video variants and a separate audio rendition group. Passing
+            # only a video-only chunk URL (from _resolve_variant) strips audio.
+            # Instead we pass the master URL and select streams explicitly.
+            is_llhls = 'llhls.m3u8' in sess.input_url
+            if is_llhls:
+                v_idx = _llhls_video_stream_index(max_height)
+                map_args = ["-map", "0:a:0", "-map", f"0:v:{v_idx}"]
+            else:
+                map_args = ["-map", "0"]
+
             cmd.extend([
                 "-i", sess.input_url,
-                "-map", "0",
+                *map_args,
                 "-c", "copy",
                 "-f", "tee", tee_spec,
             ])

--- a/app/main.py
+++ b/app/main.py
@@ -812,7 +812,7 @@ async def api_start(body: StartBody):
 
     logger.subsection("Démarrage Session FFmpeg")
     try:
-        sess = manager.start_session(m3u8_url, person=person, display_name=body.name)
+        sess = manager.start_session(m3u8_url, person=person, display_name=body.name, max_height=max_height)
         duration_ms = (time.time() - start_time) * 1000
         logger.success("Session créée avec succès", 
                       session_id=sess.id,
@@ -2323,7 +2323,8 @@ async def auto_record_task():
                                 sess = manager.start_session(
                                     input_url=hls_source,
                                     display_name=username,
-                                    person=username
+                                    person=username,
+                                    max_height=max_height,
                                 )
 
                                 if sess:

--- a/app/resolvers/chaturbate.py
+++ b/app/resolvers/chaturbate.py
@@ -230,8 +230,15 @@ def _pick_variant(variants, max_height: Optional[int]):
 
 
 async def _resolve_variant(m3u8_url: str, max_height: Optional[int] = None) -> str:
-    """If URL is a master playlist, pick a variant according to max_height."""
-    if '.m3u8' not in m3u8_url:
+    """If URL is a traditional master playlist, pick a variant according to max_height.
+
+    Only operates on playlist.m3u8 (non-LL-HLS muxed streams).
+    LL-HLS edge URLs (llhls.m3u8) carry separate audio rendition groups that are
+    only resolvable from the master playlist — ffmpeg must receive the master URL
+    so it can map both the video variant and the audio rendition. Passing a
+    video-only chunk URL to ffmpeg results in silent recordings.
+    """
+    if 'playlist.m3u8' not in m3u8_url:
         return m3u8_url
 
     try:

--- a/app/tasks/monitor.py
+++ b/app/tasks/monitor.py
@@ -23,6 +23,23 @@ MONITOR_INTERVAL = 60  # Vérifie toutes les 60 secondes
 THUMBNAIL_UPDATE_INTERVAL = 300  # Miniature offline: toutes les 5 minutes
 THUMBNAIL_UPDATE_INTERVAL_LIVE = 60  # Miniature live: toutes les 60s pour refléter l'activité
 
+async def _check_live_via_cdn(session: aiohttp.ClientSession, username: str) -> bool:
+    """Check if a model is live using the Chaturbate thumbnail CDN.
+
+    This CDN endpoint is not behind Cloudflare and does not require cookies.
+    A 200 response with a non-trivial body means the model is currently streaming.
+    """
+    url = f"https://roomimg.stream.highwebmedia.com/ri/{username}.jpg"
+    try:
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=10), ssl=False) as resp:
+            if resp.status == 200:
+                content = await resp.read()
+                return len(content) > 1000
+    except Exception:
+        pass
+    return False
+
+
 async def check_model_status(
     session: aiohttp.ClientSession,
     username: str,
@@ -38,6 +55,10 @@ async def check_model_status(
 
     Without auth cookies Chaturbate redirects ``/api/chatvideocontext/`` to the
     login page and the check silently fails (see GH #11).
+
+    When the chatvideocontext API is blocked by Cloudflare TLS fingerprinting
+    (connection reset, error code 0), the CDN thumbnail endpoint is used as a
+    reliable fallback to detect liveness without any Cloudflare dependency.
     """
     try:
         url = f"https://chaturbate.com/api/chatvideocontext/{username}/"
@@ -114,7 +135,22 @@ async def check_model_status(
                 }
     except Exception as e:
         logger.debug("Erreur vérification statut modèle", username=username, error=str(e))
-    
+
+    # Fallback: chatvideocontext is blocked by Cloudflare TLS fingerprinting.
+    # Use the thumbnail CDN which has no CF protection to detect liveness.
+    try:
+        is_live = await _check_live_via_cdn(session, username)
+        if is_live:
+            logger.debug("Statut détecté via CDN (fallback CF)", username=username, is_online=True)
+        return {
+            "is_online": is_live,
+            "viewers": 0,
+            "hls_source": None,
+            "room_status": "public" if is_live else None,
+        }
+    except Exception as e:
+        logger.debug("Erreur fallback CDN", username=username, error=str(e))
+
     return {
         "is_online": False,
         "viewers": 0,


### PR DESCRIPTION
This PR contains two independent fixes:

1. Cloudflare TLS fingerprinting causes the chatvideocontext API to return a
   connection reset (error code 0) on some server IPs. The monitor task now
   falls back to the Chaturbate thumbnail CDN to detect liveness, which is not
   behind Cloudflare and requires no cookies.

2. Chaturbate LL-HLS streams use a master playlist with separate audio rendition
   groups. The resolver was extracting a video-only variant URL and passing it to
   ffmpeg, resulting in silent recordings. The fix passes the master playlist URL
   directly to ffmpeg and uses explicit stream mapping to select the correct
   quality level.